### PR TITLE
Not subbing in bang-bang operators in expressions

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -9,3 +9,4 @@ README.Rmd
 ^README\.Rmd$
 ^README-.*\.png$
 cran-comments.md
+^CRAN-RELEASE$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: catchr
 Type: Package
 Title: Taking the Pain Out of Catching and Handling Conditions
-Version: 0.2.2.9000
+Version: 0.2.3
 Authors@R: c(
     person("Zachary", "Burchill", email = "zach.burchill.code@gmail.com", 
                                   role = c("aut", "cre", "cph"))
@@ -30,11 +30,11 @@ Depends:
     R (>= 3.2.0)
 Suggests:
 	testthat,
-    beepr,
-    crayon,
-    covr,
-    knitr,
-    rmarkdown,
-    spelling
+  beepr,
+  crayon,
+  covr,
+  knitr,
+  rmarkdown,
+  spelling
 VignetteBuilder: knitr
 Language: en-US

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: catchr
 Type: Package
 Title: Taking the Pain Out of Catching and Handling Conditions
-Version: 0.2.2
+Version: 0.2.2.9000
 Authors@R: c(
     person("Zachary", "Burchill", email = "zach.burchill.code@gmail.com", 
                                   role = c("aut", "cre", "cph"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# catchr 0.2.3
+
+## Patches
+
+ * I hate to waffle on features, but I realized that treating expressions with the `!!` and `!!!` operators differently in catchr doesn't make as much sense to me as it did before. (I honestly can't see why I ever even allowed this behavior.) The use-case Stephen (yogat3ch) pointed out made this clear, so expressions with these operators are now treated like normal expressions. This is basically a reverse of the previous `0.2.2` patch, but on reflection, I think it makes more sense to do it this way.
+ 
+
 # catchr 0.2.2
 
 ## Patches

--- a/R/catching-n-plans.R
+++ b/R/catching-n-plans.R
@@ -40,15 +40,6 @@ as_list <- function(x) {
   map(x, identity)
 }
 
-# Making quosures manually.
-# Necessary to keep any top-level bang-bangs
-make_quosure <- function(expr, env) {
-  rlang::quo() %>%
-    rlang::quo_set_expr(expr) %>%
-    rlang::quo_set_env(env)
-}
-
-
 # Just for signalling my own custom conditions
 signal_custom_condition <- function(msg, type="custom") {
   signalCondition(
@@ -248,7 +239,7 @@ make_catch_fn <- function(..., .opts = NULL) {
   function(expr) {
     .myConditions <- NULL
     baby_env <- child_env(current_env())
-    expr <- make_quosure(substitute(expr), parent.frame())
+    expr <- rlang::new_quosure(substitute(expr), parent.frame())
 
     # If you keep empty conds, make 'em now
     if (!.opts$drop_empty_conds && length(.opts$collectors) > 0)

--- a/R/catching-n-plans.R
+++ b/R/catching-n-plans.R
@@ -40,7 +40,13 @@ as_list <- function(x) {
   map(x, identity)
 }
 
-
+# Making quosures manually.
+# Necessary to keep any top-level bang-bangs
+make_quosure <- function(expr, env) {
+  rlang::quo() %>%
+    rlang::quo_set_expr(expr) %>%
+    rlang::quo_set_env(env)
+}
 
 
 # Just for signalling my own custom conditions
@@ -228,8 +234,7 @@ make_plans <- function(..., .opts = catchr_opts()) {
 #' @rdname catchers
 #' @export
 catch_expr <- function(expr, ..., .opts=NULL) {
-  expr <- enquo(expr)
-  make_catch_fn(..., .opts=.opts)(!!expr)
+  make_catch_fn(..., .opts = .opts)(expr)
 }
 
 #' @rdname catchers
@@ -243,7 +248,7 @@ make_catch_fn <- function(..., .opts = NULL) {
   function(expr) {
     .myConditions <- NULL
     baby_env <- child_env(current_env())
-    expr <- enquo(expr)
+    expr <- make_quosure(substitute(expr), parent.frame())
 
     # If you keep empty conds, make 'em now
     if (!.opts$drop_empty_conds && length(.opts$collectors) > 0)

--- a/R/check-n-clean.R
+++ b/R/check-n-clean.R
@@ -84,7 +84,7 @@ warn_of_specials <- function(x) {
       verb <- "has"
     }
     warning("`", paste(x, collapse = "`, `"),
-            "` ", verb, " special meaning as catchr input, but seem", agreement, " to already be defined elsewhere.  These previous definitions may be masked when determining condition behavior.",
+            "` ", verb, " special meaning as catchr input, but seem", agreement, " to already be defined elsewhere.  These previous definitions may be masked when determining condition behavior. (To turn these warnings off, use `catchr_default_opts(warn_about_terms=FALSE)`.)",
             immediate. = TRUE, call. = FALSE)
   }
 }

--- a/tests/testthat/test-testing.R
+++ b/tests/testthat/test-testing.R
@@ -499,13 +499,13 @@ test_that("Quasiquotation and namespaces", {
   f <- function(expr, ...) {
     quosures <- quos(...)
     q <- quo(expr)
-    catch_expr(!!q,!!!quosures)
+    rlang::eval_tidy(quo(catch_expr(!!q, !!!quosures)))
   }
 
   g <- function(expr, ...) {
     quosures <- quos(...)
     q <- quo(expr)
-    make_catch_fn(!!!quosures)(!!q)
+    rlang::eval_tidy(quo(catch_expr(!!q, !!!quosures)))
   }
 
   expect_silent({
@@ -531,3 +531,28 @@ test_that("Quasiquotation and namespaces", {
   expect_equal(gres3, "same")
 
 })
+
+test_that("Bang-bang in quasiquotation (catch_expr())", {
+  q <- catch_expr({
+    t <- "test"
+    t2 <- rlang::quo(t)
+    rlang::quo(!!t2)
+  }, warning = display_with("UHOH"))
+  expect_equal(rlang::eval_tidy(q), "test")
+})
+
+test_that("Bang-bang in quasiquotation (make_catch_fn())", {
+  catch <- make_catch_fn(warning = display_with("UHOH"))
+  q <- catch({
+    t <- "test"
+    t2 <- rlang::quo(t)
+    rlang::quo(!!t2)
+  })
+  expect_equal(rlang::eval_tidy(q), "test")
+})
+
+
+
+
+
+


### PR DESCRIPTION
`catchr` previously used `enquo()` on any expressions that were to be handled. However, if the expression had a `!!` operator in it, `enquo()` would attempt to sub in the value, which is not the desired behavior. Per #4 , this was fixed, so that the expression would not be `enquo()`ed as normal.