### PR TITLE
Pass named argument to `expr_deparse()`

### DIFF
--- a/R/check-n-clean.R
+++ b/R/check-n-clean.R
@@ -93,7 +93,7 @@ warn_of_specials <- function(x) {
 # used to get some form of "helpful-ish" name for something passed in.
 # need to use splicing to pass stuff in
 approx_arg_name <- function(x, len = 25) {
-  v <- get_expr(enquo(x)) %>% expr_deparse(999) %>% paste(collapse = "")
+  v <- get_expr(enquo(x)) %>% expr_deparse(width = 999) %>% paste(collapse = "")
   add_ellipses(v, len)
 }
 


### PR DESCRIPTION
The next release of rlang will break catchr because rlang is moving `width` after `...` to force it to be named. We plan to release within 1 month so no hurry.